### PR TITLE
Editorial: Use code tag for code block

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -54,7 +54,7 @@ partial interface mixin WindowOrWorkerGlobalScope {
 };
 </xmp>
 
-The `gc()` method must run these steps:
+The <code>gc()</code> method must run these steps:
 
  1. Let |p| be a new promise.
 


### PR DESCRIPTION
<!--
Thank you for contributing to the Test Utils Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.
-->
It seems code tags should be used for code blocks instead of back ticks.

**Current:**
<img width="871" alt="Screen Shot 2021-12-19 at 13 34 45" src="https://user-images.githubusercontent.com/3948353/146669782-38e80fd6-b131-4350-a0ba-63072cc6f5fa.png">

**With code tags:**
<img width="857" alt="Screen Shot 2021-12-19 at 13 38 10" src="https://user-images.githubusercontent.com/3948353/146669785-09311c6e-ae59-47c4-9582-0543a549446f.png">

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/testutils/4.html" title="Last updated on Jan 14, 2022, 5:40 PM UTC (2433a70)">Preview</a> | <a href="https://whatpr.org/testutils/4/2e316a8...2433a70.html" title="Last updated on Jan 14, 2022, 5:40 PM UTC (2433a70)">Diff</a>