### PR TITLE
Add missing parentheses for `[Exposed]`

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -44,7 +44,7 @@ The TestUtils Object {#the-testutils-object}
 ============================================
 
 <xmp class=idl>
-[Exposed=Window,Worker]
+[Exposed=(Window,Worker)]
 interface TestUtils {
   Promise<undefined> gc();
 };


### PR DESCRIPTION
<!--
Thank you for contributing to the Test Utils Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.
-->


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/testutils/5.html" title="Last updated on Jan 13, 2022, 5:29 PM UTC (fb6c526)">Preview</a> | <a href="https://whatpr.org/testutils/5/2e316a8...fb6c526.html" title="Last updated on Jan 13, 2022, 5:29 PM UTC (fb6c526)">Diff</a>