### PR TITLE
Make `testUtils` a namespace

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -64,9 +64,12 @@ The {{TestUtils/gc()}} method must run these steps:
 
 <h2 class=no-num id=acknowledgements>Acknowledgments</h2>
 
-Thanks to
+Thanks to the following people who have contributed to the
+Test Utils standard:
+
 Kagami Sascha Rosylight
-for being awesome!
+
+You are awesome!
 
 This standard is written by <a href=https://hoppipolla.co.uk>James Graham</a>
 (<a href=https://www.mozilla.org/>Mozilla</a>,

--- a/index.bs
+++ b/index.bs
@@ -64,6 +64,10 @@ The {{testUtils/gc()}} method must run these steps:
 
 <h2 class=no-num id=acknowledgements>Acknowledgments</h2>
 
+Thanks to
+Kagami Sascha Rosylight
+for being Awesome!
+
 This standard is written by <a href=https://hoppipolla.co.uk>James Graham</a>
 (<a href=https://www.mozilla.org/>Mozilla</a>,
 <a href=mailto:james@hoppipolla.co.uk>james@hoppipolla.co.uk</a>).

--- a/index.bs
+++ b/index.bs
@@ -66,7 +66,7 @@ The {{testUtils/gc()}} method must run these steps:
 
 Thanks to
 Kagami Sascha Rosylight
-for being Awesome!
+for being awesome!
 
 This standard is written by <a href=https://hoppipolla.co.uk>James Graham</a>
 (<a href=https://www.mozilla.org/>Mozilla</a>,

--- a/index.bs
+++ b/index.bs
@@ -45,16 +45,12 @@ The TestUtils Object {#the-testutils-object}
 
 <xmp class=idl>
 [Exposed=(Window,Worker)]
-interface TestUtils {
+namespace testUtils {
   [NewObject] Promise<undefined> gc();
-};
-
-partial interface mixin WindowOrWorkerGlobalScope {
-  [SameObject] readonly attribute TestUtils testUtils;
 };
 </xmp>
 
-The `gc()` method must run these steps:
+The {{testUtils/gc()}} method must run these steps:
 
  1. Let |p| be a new promise.
 

--- a/index.bs
+++ b/index.bs
@@ -45,12 +45,12 @@ The testUtils namespace {#the-testutils-object}
 
 <xmp class=idl>
 [Exposed=(Window,Worker)]
-namespace testUtils {
+namespace TestUtils {
   [NewObject] Promise<undefined> gc();
 };
 </xmp>
 
-The {{testUtils/gc()}} method must run these steps:
+The {{TestUtils/gc()}} method must run these steps:
 
  1. Let |p| be a new promise.
 

--- a/index.bs
+++ b/index.bs
@@ -40,7 +40,7 @@ the default shipping configuration of user agents. They must only be
 enabled in testing configurations for example with special build
 flags, or when a specific non-default preference is set.
 
-The TestUtils Object {#the-testutils-object}
+The testUtils namespace {#the-testutils-object}
 ============================================
 
 <xmp class=idl>

--- a/index.bs
+++ b/index.bs
@@ -40,7 +40,7 @@ the default shipping configuration of user agents. They must only be
 enabled in testing configurations for example with special build
 flags, or when a specific non-default preference is set.
 
-The TestUtils namespace {#the-testutils-object}
+The TestUtils Namespace {#the-testutils-namespace}
 ============================================
 
 <xmp class=idl>

--- a/index.bs
+++ b/index.bs
@@ -40,7 +40,7 @@ the default shipping configuration of user agents. They must only be
 enabled in testing configurations for example with special build
 flags, or when a specific non-default preference is set.
 
-The testUtils namespace {#the-testutils-object}
+The TestUtils namespace {#the-testutils-object}
 ============================================
 
 <xmp class=idl>


### PR DESCRIPTION
Fixes #8
Fixes #4

- [x] At least two implementers are interested (and none opposed): Well, Gecko is the only implementer.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/testutils/9.html" title="Last updated on Jan 18, 2022, 7:41 PM UTC (c64b61a)">Preview</a> | <a href="https://whatpr.org/testutils/9/61e6887...c64b61a.html" title="Last updated on Jan 18, 2022, 7:41 PM UTC (c64b61a)">Diff</a>